### PR TITLE
feat: adiciona botão copiar com funcionalidade

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -12,6 +12,7 @@
   --cor-dark-bg: #18212e;
   --cor-dark-bg-cards: #1e293b;
   --cor-dark-bg-secondary: #33415f;
+  --cor-dark-botoes: #2b364d;
   --cor-dark-toggle: #0c1118;
   --cor-dark-text: #ffffff;
 }
@@ -277,23 +278,41 @@ header img {
     transform: rotate(360deg);
   }
 }
-
-/*Botão limpar - Christiane Gomes */
-#botaoLimpar {
-  border-radius: 10px;
-  height: 35px;
-  width: 20%;
-  border: none;
-  cursor: pointer;
-  padding: 10px;
-  font-size: 10x;
-  background-image: linear-gradient();
-  color: var(--cor-dark-text);
-  background-color: #91a1af;
-  font-weight: bold;
-  letter-spacing: 0.1em;
+/* Botão limpar e copiar - Christiane Gomes e Vinnie */
+.botao-acoes {
+  display: flex;
+  gap: 10px;
+  width: 100%;
+  margin-top: 10px;
 }
 
+#botaoLimpar,
+#botaoCopiar {
+  flex: 1 1 0;
+  border-radius: 10px;
+  height: 35px;
+  border: 1px solid rgb(201, 201, 201);
+  border-radius: 10px;
+  cursor: pointer;
+  padding: 10px;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: box-shadow 0.2s;
+  background-color: var(--cor-bg-cards);
+  color: var(--cor-text);
+}
+
+#botaoLimpar:hover,
+#botaoCopiar:hover {
+  background-color: var(--cor-bg);
+}
+
+.hide {
+  display: none !important;
+}
 
 /* Footer - Vinnie */
 footer {
@@ -359,7 +378,6 @@ footer a:hover {
 .dark #apiKey {
   background-color: var(--cor-dark-bg-secondary);
   color: var(--cor-dark-text);
-  border: var(--cor-dark-bg);
 }
 
 .dark #respostaSection {
@@ -371,4 +389,16 @@ footer a:hover {
   border: 1px solid #fff;
   box-shadow: 0 0 0 1px #fff;
   transition: border 0.2s, box-shadow 0.2s;
+}
+
+.dark #botaoLimpar,
+.dark #botaoCopiar {
+  border: 1px solid #82838d;
+  background-color: var(--cor-dark-botoes);
+  color: var(--cor-dark-text);
+}
+
+.dark #botaoLimpar:hover,
+.dark #botaoCopiar:hover {
+  background-color: var(--cor-dark-bg-cards);
 }

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css"
     />
     <link rel="stylesheet" href="css/style.css" />
-    <link rel="stylesheet" href="css/responsive.css" media="screen">
+    <link rel="stylesheet" href="css/responsive.css" media="screen" />
     <link rel="icon" href="./img/logo.png" type="image/png" />
     <title>Assistente IA</title>
   </head>
@@ -21,7 +21,7 @@
           <img src="./img/logo.png" alt="logo" />
           <div>
             <h1>Assistente de IA</h1>
-            <p>Interface moderna e inteligente</p>
+            <p>Conectando dados para gerar respostas inteligentes</p>
           </div>
         </div>
 
@@ -86,11 +86,16 @@
         </div>
         <p class="resposta-texto" id="respostaTexto"></p>
       </div>
-    </div>
-
-    <!-- Botão Limpar - Christiane Gomes-->
-    <div id="limparTexto">
-    <button id="botaoLimpar" onclick="limparCampo()">Limpar</button>
+      <div class="botao-acoes">
+        <!-- Botão Copiar - Vinnie -->
+        <button id="botaoCopiar" onclick="copiarTexto()">
+          <i class="fa-solid fa-copy"></i>Copiar
+        </button>
+        <!-- Botão Limpar - Christiane Gomes-->
+        <button id="botaoLimpar" onclick="limparCampo()">
+          <i class="fa-solid fa-trash"></i>Limpar
+        </button>
+      </div>
     </div>
 
     <!-- Footer - Vinnie -->

--- a/js/main.js
+++ b/js/main.js
@@ -64,6 +64,10 @@ async function enviarPergunta() {
   // Validação de formulario - Michelle
   const erroApiKey = document.getElementById("erroApiKey");
   const erroPergunta = document.getElementById("erroPergunta");
+  const acoes = document.querySelector(".botao-acoes");
+
+  // Esconde os botões de ações - Vinnie
+  acoes.classList.add("hide");
 
   // Salva a API Key no localStorage - Vinnie
   localStorage.setItem("apiKey", apiKey);
@@ -160,6 +164,7 @@ async function enviarPergunta() {
     loading.style.display = "none";
     botao.disabled = false;
     botao.innerHTML = 'Perguntar <i class="fa-solid fa-paper-plane"></i>';
+    acoes.classList.remove("hide");
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -164,10 +164,23 @@ async function enviarPergunta() {
 }
 
 // Função que ao clicar no botão limpar, limpa o campo de pergunta e a resposta - Christiane Gomes
-document.getElementById("botaoLimpar").addEventListener("click", () => 
-{
-  document.getElementById("perguntaInput").value = ""; 
-  document.getElementById("respostaTexto").innerHTML = ""; 
-  document.getElementById("resposta-container").style.display = "none"; 
-
+document.getElementById("botaoLimpar").addEventListener("click", () => {
+  document.getElementById("perguntaInput").value = "";
+  document.getElementById("respostaTexto").innerHTML = "";
+  document.getElementById("resposta-container").style.display = "none";
 });
+
+// Função para copiar - Vinnie
+function copiarTexto() {
+  const resposta = document.getElementById("respostaTexto");
+  const texto = resposta.innerText || resposta.textContent;
+  if (texto.trim() === "") return;
+  navigator.clipboard.writeText(texto).then(() => {
+    const botao = document.getElementById("botaoCopiar");
+    const textoOriginal = botao.innerHTML;
+    botao.innerHTML = '<i class="fa-solid fa-check"></i> Copiado!';
+    setTimeout(() => {
+      botao.innerHTML = textoOriginal;
+    }, 1000);
+  });
+}


### PR DESCRIPTION
- Novo botão "Copiar" com ícone, ao lado do "Limpar", em um contêiner .botao-acoes para melhor layout.
- Botão "Limpar" atualizado com ícone e melhor posicionamento.
- CSS refatorado: estilos unificados, layout responsivo, hover, suporte a dark mode.
- Botões ocultos durante processamento e exibidos com a resposta.
- Função de copiar com feedback visual (ícone/texto).
- Removida borda não usada no input de chave da API no dark mode.